### PR TITLE
FIX: Find packages correctly

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,8 +11,6 @@ python_requires = >=3.7
 install_requires =
     pydra >= 0.14.1
 
-packages = pydra.tasks.%(subpackage)s
-
 [options.extras_require]
 doc =
     packaging

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import sys
 
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 import versioneer
 
 SUBPACKAGE = "fsl"
@@ -19,8 +19,7 @@ if __name__ == "__main__":
         setup_requires=SETUP_REQUIRES,
         version=versioneer.get_version(),
         cmdclass=versioneer.get_cmdclass(),
-        packages=[
-            f"pydra.tasks.{SUBPACKAGE}.{package}"
-            for package in find_packages("pydra/tasks/{SUBPACKAGE}")
-        ],
+        packages=find_namespace_packages(
+            include=(f"pydra.tasks.{SUBPACKAGE}", f"pydra.tasks.{SUBPACKAGE}.*")
+        ),
     )

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,26 @@
 #!/usr/bin/env python
 import sys
 
-from setuptools import setup
+from setuptools import setup, find_packages
 import versioneer
+
+SUBPACKAGE = "fsl"
 
 # Give setuptools a hint to complain if it's too old a version
 # 30.3.0 allows us to put most metadata in setup.cfg
 # Should match pyproject.toml
-SETUP_REQUIRES = ['setuptools >= 30.3.0']
+SETUP_REQUIRES = ["setuptools >= 30.3.0"]
 # This enables setuptools to install wheel on-the-fly
-SETUP_REQUIRES += ['wheel'] if 'bdist_wheel' in sys.argv else []
+SETUP_REQUIRES += ["wheel"] if "bdist_wheel" in sys.argv else []
 
 if __name__ == "__main__":
-    setup(name='pydra-fsl',
-          setup_requires=SETUP_REQUIRES,
-          version=versioneer.get_version(),
-          cmdclass=versioneer.get_cmdclass())
+    setup(
+        name=f"pydra-{SUBPACKAGE}",
+        setup_requires=SETUP_REQUIRES,
+        version=versioneer.get_version(),
+        cmdclass=versioneer.get_cmdclass(),
+        packages=[
+            f"pydra.tasks.{SUBPACKAGE}.{package}"
+            for package in find_packages("pydra/tasks/{SUBPACKAGE}")
+        ],
+    )


### PR DESCRIPTION
When there are subpackages inside the main task package, then we need to enumerate them. This can't easily be done within setup.cfg at present, or I haven't figured out how.

This should work, however.

cc @htwangtw