### PR TITLE
FIX: Correct doctest in Cluster

### DIFF
--- a/pydra/tasks/fsl/model/cluster.py
+++ b/pydra/tasks/fsl/model/cluster.py
@@ -233,8 +233,8 @@ class Cluster(ShellCommandTask):
     >>> task.inputs.out_localmax_txt_file = True
     >>> task.inputs.threshold = 2.3
     >>> task.inputs.use_mm = True
-    >>> task.cmdline
-    'cluster --in=zstat1.nii.gz --olmax=zstat1_localmax.txt --thresh=2.3000000000 --mm'
+    >>> task.cmdline  # doctest: +ELLIPSIS
+    'cluster --in=zstat1.nii.gz --thresh=2.3000000000 --olmax=.../zstat1_localmax.txt --mm'
     """
 
     input_spec = Cluster_input_spec


### PR DESCRIPTION
- Fix order of appearance for `thresh` and `olmax` in resulting command line
- Use ellipsis to avoid specifying the full path for the file which is random