### PR TITLE
FIX: Integration tests for FNIRT and SUSAN

### DIFF
--- a/pydra/tasks/fsl/preprocess/fnirt.py
+++ b/pydra/tasks/fsl/preprocess/fnirt.py
@@ -357,13 +357,7 @@ input_fields = [
 ]
 FNIRT_input_spec = specs.SpecInfo(name="Input", fields=input_fields, bases=(specs.ShellSpec,))
 
-output_fields = []
-FNIRT_output_spec = specs.SpecInfo(
-    name="Output", fields=output_fields, bases=(specs.ShellOutSpec,)
-)
-
 
 class FNIRT(ShellCommandTask):
     input_spec = FNIRT_input_spec
-    output_spec = FNIRT_output_spec
     executable = "fnirt"

--- a/pydra/tasks/fsl/preprocess/fnirt.py
+++ b/pydra/tasks/fsl/preprocess/fnirt.py
@@ -48,10 +48,11 @@ input_fields = [
     ),
     (
         "fieldcoeff_file",
-        ty.Any,
+        str,
         {
             "help_string": "name of output file with field coefficients or true",
             "argstr": "--cout={fieldcoeff_file}",
+            "output_file_template": "{in_file}_fieldwarp",
         },
     ),
     (
@@ -65,31 +66,34 @@ input_fields = [
     ),
     (
         "field_file",
-        ty.Any,
+        str,
         {
             "help_string": "name of output file with field or true",
             "argstr": "--fout={field_file}",
+            "output_file_template": "{in_file}_field",
         },
     ),
     (
         "jacobian_file",
-        ty.Any,
+        str,
         {
             "help_string": "name of file for writing out the Jacobian of the field (for diagnostic or VBM purposes)",
             "argstr": "--jout={jacobian_file}",
+            "output_file_template": "{in_file}_field_jacobian",
         },
     ),
     (
         "modulatedref_file",
-        ty.Any,
+        str,
         {
             "help_string": "name of file for writing out intensity modulated --ref (for diagnostic purposes)",
             "argstr": "--refout={modulatedref_file}",
+            "output_file_template": "{in_file}_modulated",
         },
     ),
     (
         "out_intensitymap_file",
-        ty.Any,
+        str,
         {
             "help_string": "name of files for writing information pertaining to intensity mapping",
             "argstr": "--intout={out_intensitymap_file}",
@@ -353,44 +357,7 @@ input_fields = [
 ]
 FNIRT_input_spec = specs.SpecInfo(name="Input", fields=input_fields, bases=(specs.ShellSpec,))
 
-output_fields = [
-    (
-        "fieldcoeff_file",
-        specs.File,
-        {
-            "help_string": "file with field coefficients",
-            "requires": ["in_file"],
-            "output_file_template": "{in_file}_fieldwarp",
-        },
-    ),
-    (
-        "field_file",
-        specs.File,
-        {
-            "help_string": "file with warp field",
-            "requires": ["in_file"],
-            "output_file_template": "{in_file}_field",
-        },
-    ),
-    (
-        "jacobian_file",
-        specs.File,
-        {
-            "help_string": "file containing Jacobian of the field",
-            "requires": ["in_file"],
-            "output_file_template": "{in_file}_field_jacobian",
-        },
-    ),
-    (
-        "modulatedref_file",
-        specs.File,
-        {
-            "help_string": "file containing intensity modulated --ref",
-            "requires": ["in_file"],
-            "output_file_template": "{in_file}_modulated",
-        },
-    ),
-]
+output_fields = []
 FNIRT_output_spec = specs.SpecInfo(
     name="Output", fields=output_fields, bases=(specs.ShellOutSpec,)
 )

--- a/pydra/tasks/fsl/preprocess/susan.py
+++ b/pydra/tasks/fsl/preprocess/susan.py
@@ -2,6 +2,31 @@ from pydra.engine import specs
 from pydra import ShellCommandTask
 import typing as ty
 
+
+def format_usans(field: ty.Sequence[ty.Tuple[str, float]] = None) -> str:
+    """Format usans argument to its appropriate argstr.
+
+    Examples
+    --------
+    >>> format_usans([])
+    '0'
+    >>> format_usans([('/path/to/file', 2.5)])
+    '1 /path/to/file 2.5'
+    >>> format_usans([('/path/to/file1', 10.5), ('/path/to/file2', 22.1)])
+    '2 /path/to/file1 10.5 /path/to/file2 22.1'
+    """
+    try:
+        n_usans = len(field)
+    except TypeError:
+        n_usans = 0
+
+    if n_usans > 0:
+        usan_bt = " ".join([f"{usan} {bt}" for usan, bt in field])
+        return f"{n_usans} {usan_bt}"
+    else:
+        return f"{n_usans}"
+
+
 input_fields = [
     (
         "in_file",
@@ -54,12 +79,12 @@ input_fields = [
         },
     ),
     (
-        "n_usans",
-        int,
-        0,
+        "usans",
+        ty.Sequence[ty.Tuple[str, float]],
+        [],
         {
             "help_string": "determines whether the smoothing area (USAN) is to be found from secondary images (0, 1 or 2). A negative value for any brightness threshold will auto-set the threshold at 10% of the robust range",
-            "argstr": "{n_usans}",
+            "formatter": format_usans,
             "position": 6,
         },
     ),

--- a/pydra/tasks/fsl/preprocess/susan.py
+++ b/pydra/tasks/fsl/preprocess/susan.py
@@ -54,12 +54,12 @@ input_fields = [
         },
     ),
     (
-        "usans",
-        list,
-        [],
+        "n_usans",
+        int,
+        0,
         {
             "help_string": "determines whether the smoothing area (USAN) is to be found from secondary images (0, 1 or 2). A negative value for any brightness threshold will auto-set the threshold at 10% of the robust range",
-            "argstr": "",
+            "argstr": "{n_usans}",
             "position": 6,
         },
     ),

--- a/pydra/tasks/fsl/preprocess/susan.py
+++ b/pydra/tasks/fsl/preprocess/susan.py
@@ -15,16 +15,7 @@ def format_usans(field: ty.Sequence[ty.Tuple[str, float]]) -> str:
     >>> format_usans([('/path/to/file1', 10.5), ('/path/to/file2', 22.1)])
     '2 /path/to/file1 10.5 /path/to/file2 22.1'
     """
-    try:
-        n_usans = len(field)
-    except TypeError:
-        n_usans = 0
-
-    if n_usans > 0:
-        usan_bt = " ".join([f"{usan} {bt}" for usan, bt in field])
-        return f"{n_usans} {usan_bt}"
-    else:
-        return f"{n_usans}"
+    return " ".join([f"{len(field)}"] + [f"{usan} {bt}" for usan, bt in field])
 
 
 input_fields = [

--- a/pydra/tasks/fsl/preprocess/susan.py
+++ b/pydra/tasks/fsl/preprocess/susan.py
@@ -3,7 +3,7 @@ from pydra import ShellCommandTask
 import typing as ty
 
 
-def format_usans(field: ty.Sequence[ty.Tuple[str, float]] = None) -> str:
+def format_usans(field: ty.Sequence[ty.Tuple[str, float]]) -> str:
     """Format usans argument to its appropriate argstr.
 
     Examples


### PR DESCRIPTION
For FNIRT, moving the output file declarations to the input spec worked.

~~For SUSAN, I am not quite sure how to accomodate translation of `usans: list` to `n_usans [<usan1> <bt1> <usan2> <bt2>]`. At the very least, an empty list should produce `n_usans = 0`. That's what I went for.~~

For SUSAN, I added an appropriate formatter function for the `usans` argument as suggested by @satra  